### PR TITLE
Take authors on command-line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Generate an open source license for your projects.
 
 ## Usage:
 
-    licgen [license]
+    licgen <license> [<author1>, [<author2> ...]]
 
 Too see the available license templates:
 

--- a/lib/license-generator/app.rb
+++ b/lib/license-generator/app.rb
@@ -3,6 +3,7 @@ require 'thor'
 module LicenseGenerator
   class App < Thor
     include Thor::Actions
+    attr_accessor :authors
 
     # Path to the templates
     def self.source_root
@@ -17,6 +18,7 @@ module LicenseGenerator
     end
 
     def method_missing(meth, *args)
+      self.authors = args.empty? ? option(:authors) : args.join(', ')
       template "#{meth}.erb", "LICENSE"
     end
 

--- a/templates/afl-3.0.erb
+++ b/templates/afl-3.0.erb
@@ -1,4 +1,4 @@
-Copyright (c) <%= Time.now.year %> <%= option(:name) %>
+Copyright (c) <%= Time.now.year %> <%= authors %>
 
 Academic Free License ("AFL") v. 3.0
 

--- a/templates/apache-2.0.erb
+++ b/templates/apache-2.0.erb
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright <%= Time.now.year %> <%= option(:name) %>
+   Copyright <%= Time.now.year %> <%= authors %>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/templates/bsd.erb
+++ b/templates/bsd.erb
@@ -1,4 +1,4 @@
-Copyright (c) <%= Time.now.year %>, <%= option(:name) %>
+Copyright (c) <%= Time.now.year %>, <%= authors %>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/templates/gpl-1.0.erb
+++ b/templates/gpl-1.0.erb
@@ -1,4 +1,4 @@
-Copyright (C) <%= Time.now.year %> <%= option(:name) %>
+Copyright (C) <%= Time.now.year %> <%= authors %>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/templates/gpl-2.0.erb
+++ b/templates/gpl-2.0.erb
@@ -1,4 +1,4 @@
-Copyright (C) <%= Time.now.year %> <%= option(:name) %>
+Copyright (C) <%= Time.now.year %> <%= authors %>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/templates/gpl-3.0.erb
+++ b/templates/gpl-3.0.erb
@@ -1,4 +1,4 @@
-Copyright (C) <%= Time.now.year %> <%= option(:name) %>
+Copyright (C) <%= Time.now.year %> <%= authors %>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/templates/mit.erb
+++ b/templates/mit.erb
@@ -1,4 +1,4 @@
-Copyright (c) <%= Time.now.year %> <%= option(:name) %>
+Copyright (c) <%= Time.now.year %> <%= authors %>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/templates/mozilla-2.0.erb
+++ b/templates/mozilla-2.0.erb
@@ -1,6 +1,6 @@
 Mozilla Public License, version 2.0
 
-Copyright (c) <%= Time.now.year %>, <%= option(:name) %>
+Copyright (c) <%= Time.now.year %>, <%= authors %>
 
 1. Definitions
 


### PR DESCRIPTION
When doing things programatically, it's annoying to have to do input on a
prompt; even when doing things interactively, it still is. :)

This allows us to enter some number of authors after the license name;
if it's zero, we'll still prompt like before.

Since the author is part of every single license, pull out the prompting
one level to licgen itself, rather than erb.
