### PR TITLE
Make SIGINTs nicer.

### DIFF
--- a/lib/license-generator.rb
+++ b/lib/license-generator.rb
@@ -5,6 +5,8 @@ rescue LoadError
   # oh well!
 end
 
+require 'nice-sigint'
+
 module LicenseGenerator
   autoload :App, "license-generator/app"
 end

--- a/license-generator.gemspec
+++ b/license-generator.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "license-generator"
 
   s.add_dependency "thor"
+  s.add_dependency "nice-sigint"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Previously, a SIGINT would cause a stack trace:

```
[$]> ../license-generator/bin/licgen wtfpl-2.0
Authors: ^C/Users/pearson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/shell/basic.rb:42:in `gets': Interrupt
        from /Users/pearson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/shell/basic.rb:42:in `ask'
        from /Users/pearson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/shell.rb:69:in `ask'
        from /Users/pearson/Documents/license-generator/lib/license-generator/app.rb:46:in `option'
        from /Users/pearson/Documents/license-generator/lib/license-generator/app.rb:21:in `method_missing'
        from /Users/pearson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
        from /Users/pearson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/task.rb:108:in `run'
        from /Users/pearson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
        from /Users/pearson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
        from /Users/pearson/.rvm/gems/ruby-1.9.2-p180/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
        from ../license-generator/bin/licgen:7:in `<main>'

[$]>
```

This is confusing, because pressing ctrl-c is a perfectly normal thing to do,
and a stack trace indicates that something went terribly wrong (even if it
didn't).  Worse, it's ugly!

Now, thanks to [the smallest gem in existence](https://github.com/xiongchiamiov/nice-sigint), this is no longer the case:

```
[$]> ../license-generator/bin/licgen wtfpl-2.0
Authors: ^C
[$]>
```
