### PR TITLE
(wip) Improve help output.

### DIFF
--- a/features/step_definitions/license-generator_steps.rb
+++ b/features/step_definitions/license-generator_steps.rb
@@ -8,8 +8,7 @@ Then /^the file "([^"]*)" should contain a copyright notice for "([^"]*)"$/ do |
 end
 
 Then /^I should see the generic help output$/ do
+  assert_partial_output("licgen <license> [<author1>, [<author2> ...]]", all_output)
   assert_partial_output("licgen help [COMMAND]", all_output)
   assert_partial_output("licgen list", all_output)
-  assert_partial_output("licgen bsd", all_output)
-  assert_partial_output("licgen mit", all_output)
 end

--- a/lib/license-generator/app.rb
+++ b/lib/license-generator/app.rb
@@ -22,15 +22,17 @@ module LicenseGenerator
       template "#{meth}.erb", "LICENSE"
     end
 
-    # Override Thor#help to include templates.
     def help(task = nil)
-      super
       unless task
-        say "Templates:"
-        templates.each do |template|
-          say "  licgen #{template}\t# Generate #{template} license"
-        end
+        say "Generate an open source license for your project."
+        say ""
+        say "Usage:"
+        say "  licgen <license> [<author1>, [<author2> ...]]"
+        say ""
+
+        say "Other "
       end
+      super
     end
 
     no_tasks do

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -32,12 +32,6 @@ describe LicenseGenerator::App do
     @app.list
   end
 
-  it "displays the templates in the help command output" do
-    @app.should_receive(:say).with('Templates:')
-    @app.should_receive(:say).exactly(@app.templates.size).times.with(/^\s{2}licgen ([A-Za-z0-9\-\._]+)\b\s{1,}#\sGenerate\s([A-Za-z0-9\-\._]+)\slicense/)
-    @app.help
-  end
-
   it "generates a template with a valid template name" do
     @app.should_receive(:template).with('mit.erb', 'LICENSE')
     @app.mit('Justin Blake')


### PR DESCRIPTION
Add a real usage example, and remove list of templates.

We don't need to list available templates in the help output because we
have a command for that, and it will clutter up help as the list grows.

Note: this commit breaks the cucumber features. Expect this branch to be
rebased before merging.
